### PR TITLE
fix: export plugin directly

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -174,4 +174,4 @@ function viteTemplateHtml(options: Options) {
   return plugins;
 }
 
-export default viteTemplateHtml;
+export = viteTemplateHtml;


### PR DESCRIPTION
The current usage will have problems under Native ESM, such as using `vite.config.mts`

```ts
// vite.config.mts
import templateHtmlPlugin from 'vite-plugin-template-html';

templateHtmlPlugin() // throws, because 'templateHtmlPlugin' is an object with 'default' property
```

If we use `.default` manually there will be type issues.

```ts
// vite.config.mts
import templateHtmlPlugin from 'vite-plugin-template-html';

templateHtmlPlugin.default() // TS Error because 'templateHtmlPlugin' is of type function
```

---

However, it should also be noted that this modification is a breaking change to the original use of uncompiled CommonJS.

```diff
- const { default: templateHtmlPlugin } = require('vite-plugin-template-html');
+ const templateHtmlPlugin = require('vite-plugin-template-html');
```